### PR TITLE
Add the baseurl to the permalinks in the RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -13,8 +13,8 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <link>{{ site.url }}{{ post.url }}</link>
-        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+        <link>{{ site.url }}{{ site.baseurl }}{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.url }}{{ site.baseurl }}{{ post.url }}</guid>
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
Otherwise it leads to 404s like http://blog.garstasio.com/events/
